### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-
 ## [Unreleased]
 
 ### Added
-
 - Add `global.podSecurityStandards.enforced` value for PSS migration.
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
 
 ## [0.5.0] - 2023-07-13
 
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added feature to enable/disable operator. 
+- Added feature to enable/disable operator.
 
 ## [0.1.0] - 2022-06-28
 

--- a/helm/aws-servicequotas-operator/values.yaml
+++ b/helm/aws-servicequotas-operator/values.yaml
@@ -15,7 +15,7 @@ image:
   name: "giantswarm/aws-servicequotas-operator"
   tag: "[[ .Version ]]"
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 pod:
   user:
@@ -44,7 +44,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-    - ALL
+      - ALL
 
 global:
   podSecurityStandards:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
